### PR TITLE
Update installer to 2.0.17

### DIFF
--- a/installer
+++ b/installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DNSCRYPT_VER=2.0.16
+DNSCRYPT_VER=2.0.17
 
 BOLD="\033[1m"
 NORM="\033[0m"


### PR DESCRIPTION
Version 2.0.17
 - Go >= 1.11 is now supported
 - The flipside is that Windows XP is not supported any more :(
 - When dropping privileges, there is no supervisor process any more.
 - DNS options used to be cleared from DNS queries, with the exception
of flags and payload sizes. This is not the case any more.
 - Android builds use a newer NDK, and add compatibility with API 19.
 - DoH queries are smaller, since workarounds are not required any more
after Google updated their implementation.